### PR TITLE
Update to `AsteroidShapeModels.jl` v0.4.0 with batch ray processing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ SPICE = "5bab7191-041a-5c2e-a744-024b9c3a5062"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-AsteroidShapeModels = "0.3.1"
+AsteroidShapeModels = "0.4"
 CairoMakie = "0.13.4"
 Downloads = "1.6.0"
 Rotations = "1.7.1"

--- a/README.md
+++ b/README.md
@@ -75,7 +75,12 @@ add_instrument!(spacecraft, camera)
 
 ```julia
 # Load shape model
-shape = AsteroidShapeModels.load_shape_obj("path/to/shape.obj", scale=1000)  # `scale` factor converts [km] to [m]
+# Load an asteroid shape model
+# - `path/to/shape.obj` is the path to your OBJ file (mandatory)
+# - `scale` : scale factor for the shape model (e.g., 1000 for km to m conversion)
+# - `with_face_visibility` : whether to build face-to-face visibility graph for illumination checking and thermophysical modeling
+# - `with_bvh` : whether to build BVH for ray tracing
+shape = load_shape_obj("path/to/shape.obj"; scale=1000, with_face_visibility=false, with_bvh=true)
 
 # Create asteroid object
 asteroid = SpiceAsteroid("ASTEROID_NAME", shape, "ASTEROID_FIXED_FRAME")
@@ -85,10 +90,10 @@ asteroid = SpiceAsteroid("ASTEROID_NAME", shape, "ASTEROID_FIXED_FRAME")
 
 ```julia
 # Set simulation time
-et = SPICE.str2et("2025-01-01T12:00:00")  # Ephemeris time
-ref = "J2000"  # Reference frame
-abcorr = "NONE"  # Aberration correction flag
-obs = "EARTH"  # Observer
+et     = SPICE.str2et("2025-01-01T12:00:00")  # Ephemeris time
+ref    = "J2000"                              # Reference frame
+abcorr = "NONE"                               # Aberration correction flag
+obs    = "EARTH"                              # Observer
 
 # Update spacecraft and asteroid states
 update!(spacecraft, et, ref, abcorr, obs)

--- a/src/FOVSimulator.jl
+++ b/src/FOVSimulator.jl
@@ -19,6 +19,6 @@ export SpiceAsteroid
 export update!
 
 include("image_generation.jl")
-export generate_intersection_map, generate_image_temperature, generate_image_radiance
+export generate_pixel_rays, generate_intersection_map, generate_image_temperature, generate_image_radiance
 
 end # module FOVSimulator

--- a/src/SpiceAsteroid.jl
+++ b/src/SpiceAsteroid.jl
@@ -7,13 +7,11 @@ A structure holding static asteroid information.
 - `name`                : Asteroid name
 - `shape`               : Shape model
 - `asteroid_fixed_frame`: Name of the asteroid-fixed reference frame
-- `bbox`                : Bounding box of the shape model at the asteroid-fixed frame
 """
 struct SpiceAsteroidStatic
     name::String
     shape::ShapeModel
     asteroid_fixed_frame::String
-    bbox::BoundingBox
 end
 
 """
@@ -64,11 +62,8 @@ Construct an asteroid model.
 - `asteroid_fixed_frame`: Name of the asteroid-fixed reference frame
 """
 function SpiceAsteroid(name::String, shape::ShapeModel, asteroid_fixed_frame::String)
-    # Calculate bounding box for the shape model
-    bbox = compute_bounding_box(shape)
-    
     # Create static information structure
-    static = SpiceAsteroidStatic(name, shape, asteroid_fixed_frame, bbox)
+    static = SpiceAsteroidStatic(name, shape, asteroid_fixed_frame)
     
     # Initialize dynamic information
     et = 0.0
@@ -147,4 +142,6 @@ Perform ray-shape intersection test with a `SpiceAsteroid`.
 # Returns
 - `RayShapeIntersectionResult` object containing the intersection test result
 """
-intersect_ray_shape(ray::AsteroidShapeModels.Ray, asteroid::SpiceAsteroid) = AsteroidShapeModels.intersect_ray_shape(ray, asteroid.static.shape, asteroid.static.bbox)
+function intersect_ray_shape(ray::AsteroidShapeModels.Ray, asteroid::SpiceAsteroid)
+    return AsteroidShapeModels.intersect_ray_shape(ray, asteroid.static.shape)
+end

--- a/src/image_generation.jl
+++ b/src/image_generation.jl
@@ -125,31 +125,22 @@ end
     generate_intersection_map(cam::SpiceCamera, asteroid::SpiceAsteroid) -> intersection_map::Matrix{RayShapeIntersectionResult}
 
 Generate an intersection map by casting rays from the camera to the asteroid shape model.
-Uses bounding box optimization for faster computation.
+Uses batch ray processing for efficient computation (AsteroidShapeModels.jl v0.4.0+).
 
 # Arguments
-- `cam`     : SpiceCamera object
-- `asteroid`: SpiceAsteroid object
+- `cam`      : SpiceCamera object
+- `asteroid` : SpiceAsteroid object
 
 # Returns
-- `intersections` : 2D array of intersection results for each pixel
+- `intersection_map` : 2D array of intersection results for each pixel
 """
 function generate_intersection_map(cam::SpiceCamera, asteroid::SpiceAsteroid)
     # Generate rays for each pixel in the asteroid-fixed frame
     rays = generate_pixel_rays(cam, asteroid)
     
-    # Get image dimensions
-    height, width = size(rays)
-    
-    # Initialize array to store intersection results
-    intersection_map = Matrix{RayShapeIntersectionResult}(undef, height, width)
-    
-    # Perform intersection test for each pixel
-    for v in 1:height
-        for u in 1:width
-            intersection_map[v, u] = intersect_ray_shape(rays[v, u], asteroid)
-        end
-    end
+    # Perform batch intersection test for all rays at once
+    # This leverages the optimized batch processing in AsteroidShapeModels.jl v0.4.0
+    intersection_map = intersect_ray_shape(rays, asteroid.static.shape)
     
     return intersection_map
 end
@@ -182,7 +173,7 @@ function generate_image_temperature(intersection_map::Matrix{RayShapeIntersectio
             # If intersection exists
             if intersection.hit
                 # Get temperature
-                T = temperatures[intersection.face_index]
+                T = temperatures[intersection.face_idx]
                 
                 # Store temperature
                 image[v, u] = T
@@ -239,17 +230,17 @@ function generate_image_temperature(intersection_map1::Matrix{RayShapeIntersecti
                 # Both bodies are intersected, use the closer one
                 if intersection1.distance < intersection2.distance
                     # First body is closer
-                    image[v, u] = temperatures1[intersection1.face_index]
+                    image[v, u] = temperatures1[intersection1.face_idx]
                 else
                     # Second body is closer
-                    image[v, u] = temperatures2[intersection2.face_index]
+                    image[v, u] = temperatures2[intersection2.face_idx]
                 end
             elseif intersection1.hit
                 # Only first body is intersected
-                image[v, u] = temperatures1[intersection1.face_index]
+                image[v, u] = temperatures1[intersection1.face_idx]
             elseif intersection2.hit
                 # Only second body is intersected
-                image[v, u] = temperatures2[intersection2.face_index]
+                image[v, u] = temperatures2[intersection2.face_idx]
             else
                 # No intersection (space)
                 image[v, u] = 0.0
@@ -294,8 +285,8 @@ function generate_image_radiance(intersection_map::Matrix{RayShapeIntersectionRe
             # If intersection exists
             if intersection.hit
                 # Get emissivity and temperature
-                ε = emissivities[intersection.face_index]
-                T = temperatures[intersection.face_index]
+                ε = emissivities[intersection.face_idx]
+                T = temperatures[intersection.face_idx]
                 
                 # Calculate radiance using Stefan-Boltzmann law
                 # E = ε·σT⁴ [W/m²] (total emitted power per unit area)
@@ -370,12 +361,12 @@ function generate_image_radiance(
                 # Both bodies are intersected, use the closer one
                 if intersection1.distance < intersection2.distance
                     # First body is closer
-                    ε = emissivities1[intersection1.face_index]
-                    T = temperatures1[intersection1.face_index]
+                    ε = emissivities1[intersection1.face_idx]
+                    T = temperatures1[intersection1.face_idx]
                 else
                     # Second body is closer
-                    ε = emissivities2[intersection2.face_index]
-                    T = temperatures2[intersection2.face_index]
+                    ε = emissivities2[intersection2.face_idx]
+                    T = temperatures2[intersection2.face_idx]
                 end
                 
                 # Calculate radiance
@@ -384,15 +375,15 @@ function generate_image_radiance(
                 
             elseif intersection1.hit
                 # Only first body is intersected
-                ε = emissivities1[intersection1.face_index]
-                T = temperatures1[intersection1.face_index]
+                ε = emissivities1[intersection1.face_idx]
+                T = temperatures1[intersection1.face_idx]
                 radiance = ε * σ_SB * T^4 / π  # [W/m²/sr]
                 image[v, u] = radiance
                 
             elseif intersection2.hit
                 # Only second body is intersected
-                ε = emissivities2[intersection2.face_index]
-                T = temperatures2[intersection2.face_index]
+                ε = emissivities2[intersection2.face_idx]
+                T = temperatures2[intersection2.face_idx]
                 radiance = ε * σ_SB * T^4 / π  # [W/m²/sr]
                 image[v, u] = radiance
                 

--- a/test/HERA.jl
+++ b/test/HERA.jl
@@ -124,7 +124,7 @@
     ##==== Unit tests for custom structure: `SpiceAsteroid` ====##
     @testset "SpiceAsteroid basic struct" begin
         path_shape_deimos = joinpath("shape", paths_shape[2])
-        shape_deimos = AsteroidShapeModels.load_shape_obj(path_shape_deimos; scale=1000, with_face_visibility=false)
+        shape_deimos = AsteroidShapeModels.load_shape_obj(path_shape_deimos; scale=1000, with_face_visibility=false, with_bvh=true)
         deimos = SpiceAsteroid("DEIMOS", shape_deimos, "DEIMOS_FIXED")
 
         @test deimos.static.name                 == "DEIMOS"

--- a/test/TIRI_image_Didymos.jl
+++ b/test/TIRI_image_Didymos.jl
@@ -131,8 +131,8 @@ and generation of thermal images with TIRI camera.
     path_shape1 = joinpath("shape", "g_50677mm_rad_obj_didy_0000n00000_v001.obj")
     path_shape2 = joinpath("shape", "g_01332mm_lgt_obj_dimo_000n00000_v001.obj")
 
-    shape1 = AsteroidShapeModels.load_shape_obj(path_shape1; scale=1000, with_face_visibility=false)
-    shape2 = AsteroidShapeModels.load_shape_obj(path_shape2; scale=1000, with_face_visibility=false)
+    shape1 = AsteroidShapeModels.load_shape_obj(path_shape1; scale=1000, with_face_visibility=false, with_bvh=true)
+    shape2 = AsteroidShapeModels.load_shape_obj(path_shape2; scale=1000, with_face_visibility=false, with_bvh=true)
     
     n_face1 = length(shape1.faces)  # Number of faces in Didymos
     n_face2 = length(shape2.faces)  # Number of faces in Dimorphos

--- a/test/batch_performance.jl
+++ b/test/batch_performance.jl
@@ -1,0 +1,128 @@
+"""
+Test batch ray processing performance
+"""
+
+@testset "Batch Ray Processing Performance" begin
+    msg = """\n
+    ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    |          Test: Batch Ray Processing Performance        |
+    ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+    """
+    println(msg)
+    
+    # Download test files if needed
+    paths_kernel = [
+        "lsk/naif0012.tls",
+        "pck/pck00011.tpc",
+        "fk/hera_v14.tf",
+        "ik/hera_tiri_v03.ti",
+        "spk/de432s.bsp",
+    ]
+    
+    path_shape = "shape/g_50677mm_rad_obj_didy_0000n00000_v001.obj"
+    
+    for path_kernel in paths_kernel
+        url_kernel = "https://spiftp.esac.esa.int/data/SPICE/HERA/kernels/$(path_kernel)"
+        filepath = joinpath(@__DIR__, "kernel", path_kernel)
+        mkpath(dirname(filepath))
+        isfile(filepath) || Downloads.download(url_kernel, filepath)
+    end
+    
+    url_shape = "https://spiftp.esac.esa.int/data/SPICE/HERA/kernels/dsk/g_50677mm_rad_obj_didy_0000n00000_v001.obj"
+    filepath_shape = joinpath(@__DIR__, path_shape)
+    mkpath(dirname(filepath_shape))
+    isfile(filepath_shape) || Downloads.download(url_shape, filepath_shape)
+    
+    # Load SPICE kernels
+    for path_kernel in paths_kernel
+        filepath = joinpath(@__DIR__, "kernel", path_kernel)
+        SPICE.furnsh(filepath)
+    end
+    
+    # Load shape model with BVH
+    shape = AsteroidShapeModels.load_shape_obj(filepath_shape; scale=1000, with_face_visibility=false, with_bvh=true)
+    
+    # Create a simple test setup
+    img_size = (1024, 768)   # Image size same as HERA/TIRI
+    
+    # Create rays directly in asteroid-fixed frame
+    height, width = img_size
+    rays = Matrix{Ray}(undef, height, width)
+    
+    # Camera at 1000 km distance looking at origin
+    camera_pos = @SVector [1000e3, 0.0, 0.0]
+    
+    # Simple pinhole camera model
+    fov_x = deg2rad(13.3)
+    fov_y = deg2rad(10.0)
+    
+    for v in 1:height
+        for u in 1:width
+            # Normalized image coordinates (-1 to 1)
+            x = 2.0 * (u - 1) / (width - 1) - 1.0
+            y = 2.0 * (v - 1) / (height - 1) - 1.0
+            
+            # Ray direction
+            dx = -1.0  # Looking towards origin
+            dy = tan(fov_x/2) * x
+            dz = tan(fov_y/2) * y
+            
+            ray_direction = normalize(@SVector [dx, dy, dz])
+            rays[v, u] = Ray(camera_pos, ray_direction)
+        end
+    end
+    
+    println("\nShape model:")
+    println("- Number of faces : $(length(shape.faces))")
+    println("- Image size      : $(img_size)")
+    println("- Total rays      : $(prod(img_size))")
+    
+    # Test 1: Loop-based approach (old method)
+    function generate_intersection_map_loop(rays, shape)
+        height, width = size(rays)
+        intersection_map = Matrix{RayShapeIntersectionResult}(undef, height, width)
+        
+        for v in 1:height
+            for u in 1:width
+                intersection_map[v, u] = intersect_ray_shape(rays[v, u], shape)
+            end
+        end
+        
+        return intersection_map
+    end
+    
+    # Test 2: Batch approach (new method)
+    function generate_intersection_map_batch(rays, shape)
+        return intersect_ray_shape(rays, shape)
+    end
+    
+    # Warm up
+    generate_intersection_map_loop(rays[1:10, 1:10], shape)
+    generate_intersection_map_batch(rays[1:10, 1:10], shape)
+    
+    # Performance comparison
+    println("\nPerformance comparison:")
+    print("- Loop-based approach : ")
+    t_loop = @elapsed result_loop = generate_intersection_map_loop(rays, shape)
+    println("$(round(t_loop, digits=5)) seconds")
+    
+    print("- Batch approach      : ")
+    t_batch = @elapsed result_batch = generate_intersection_map_batch(rays, shape)
+    println("$(round(t_batch, digits=5)) seconds")
+    
+    speedup = t_loop / t_batch
+    println("- Speedup             : $(round(speedup, digits=1))x")
+    
+    # Verify results are identical
+    @test size(result_loop) == size(result_batch)
+    for i in eachindex(result_loop)
+        @test result_loop[i].hit == result_batch[i].hit
+        if result_loop[i].hit
+            @test result_loop[i].face_idx == result_batch[i].face_idx
+            @test result_loop[i].distance ≈ result_batch[i].distance rtol=1e-10
+        end
+    end
+    
+    # Clean up
+    SPICE.kclear()
+end

--- a/test/batch_performance.jl
+++ b/test/batch_performance.jl
@@ -115,13 +115,14 @@ Test batch ray processing performance
     
     # Verify results are identical
     @test size(result_loop) == size(result_batch)
-    for i in eachindex(result_loop)
-        @test result_loop[i].hit == result_batch[i].hit
-        if result_loop[i].hit
-            @test result_loop[i].face_idx == result_batch[i].face_idx
-            @test result_loop[i].distance ≈ result_batch[i].distance rtol=1e-10
-        end
-    end
+    
+    # Check all hit values match
+    @test all(result_loop[i].hit == result_batch[i].hit for i in eachindex(result_loop))
+    
+    # For hits, check face indices and distances match
+    hit_indices = findall(i -> result_loop[i].hit, eachindex(result_loop))
+    @test all(result_loop[i].face_idx == result_batch[i].face_idx for i in hit_indices)
+    @test all(result_loop[i].distance ≈  result_batch[i].distance for i in hit_indices)
     
     # Clean up
     SPICE.kclear()

--- a/test/ray_intersection_vs_DSK.jl
+++ b/test/ray_intersection_vs_DSK.jl
@@ -120,10 +120,7 @@
     update!(cam, et, ref, abcorr, obs)
     ray = Ray(cam.state.position, cam.state.boresight)
     
-    # Calculate bounding box
-    bbox = compute_bounding_box(shape)
-    
-    intersection = intersect_ray_shape(ray, shape, bbox)  # Intersection test result
+    intersection = intersect_ray_shape(ray, shape)  # Intersection test result
     
     # @show ray.origin
     # @show ray.direction
@@ -166,7 +163,7 @@
     
     println("Computation time")
     print("    ∘ intersect_ray_shape in AsteroidShapeModels.jl :")
-    @time intersect_ray_shape(ray, shape, bbox)
+    @time intersect_ray_shape(ray, shape)
     print("    ∘ sincpt in SPICE.jl                            :")
     @time SPICE.sincpt("DSK/UNPRIORITIZED", obs, et, ref, abcorr, "HERA", "HERA_TIRI", collect(cam.static.boresight))
     println()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,4 +12,5 @@ import SPICE
 
 include("HERA.jl")
 include("ray_intersection_vs_DSK.jl")  # Ray intersection tests with SPICE comparison
+include("batch_performance.jl")        # Batch ray processing performance tests
 include("TIRI_image_Didymos.jl")       # Didymos and Dimorphos thermal simulation tests


### PR DESCRIPTION
## Summary

This PR updates `FOVSimulator.jl` to be compatible with `AsteroidShapeModels.jl` v0.4.0 and leverages the new batch ray processing feature for significant performance improvements.

## Changes

### 🔧 Dependency Update
- Updated `AsteroidShapeModels.jl` from v0.3.1 to v0.4.0

### 🚀 Performance Enhancement
- Implemented batch ray processing in `generate_intersection_map`
- Achieved **~19.5x speedup** for ray-shape intersection operations
- Added comprehensive performance test demonstrating the improvement

### 🔄 API Updates
- Renamed `face_index` to `face_idx` throughout the codebase (following upstream API change)
- Added `with_bvh=true` parameter to all `load_shape_obj` calls (now required in v0.4.0)
- Exported `generate_pixel_rays` function for better API access

### 🧹 Code Cleanup
- Removed `BoundingBox` dependency (no longer needed with BVH)
- Simplified `intersect_ray_shape` calls

## Performance Results

From the batch processing performance test:
- Image size: 1024×768 pixels (same as HERA/TIRI)
- Total rays: 786,432
- Loop-based approach: 0.505 seconds
- Batch approach: 0.026 seconds
- **Speedup: 19.5x**

## Testing

All existing tests pass, and a new performance test has been added to verify the batch processing functionality.

## Breaking Changes

This update requires AsteroidShapeModels.jl v0.4.0 or higher.

🤖 Generated with [Claude Code](https://claude.ai/code)