### PR TITLE
Fix batch ray intersection methods for full `AsteroidShapeModels.jl` v0.4.0 compatibility

### DIFF
--- a/src/SpiceAsteroid.jl
+++ b/src/SpiceAsteroid.jl
@@ -145,3 +145,35 @@ Perform ray-shape intersection test with a `SpiceAsteroid`.
 function intersect_ray_shape(ray::AsteroidShapeModels.Ray, asteroid::SpiceAsteroid)
     return AsteroidShapeModels.intersect_ray_shape(ray, asteroid.static.shape)
 end
+
+"""
+    intersect_ray_shape(rays::Vector{Ray}, asteroid::SpiceAsteroid) -> Vector{RayShapeIntersectionResult}
+
+Perform batch ray-shape intersection test with a `SpiceAsteroid` for a vector of rays.
+
+# Arguments
+- `rays`     : Vector of rays at the asteroid-fixed frame
+- `asteroid` : `SpiceAsteroid` object
+
+# Returns
+- Vector of `RayShapeIntersectionResult` objects
+"""
+function intersect_ray_shape(rays::AbstractVector{AsteroidShapeModels.Ray}, asteroid::SpiceAsteroid)
+    return AsteroidShapeModels.intersect_ray_shape(rays, asteroid.static.shape)
+end
+
+"""
+    intersect_ray_shape(rays::Matrix{Ray}, asteroid::SpiceAsteroid) -> Matrix{RayShapeIntersectionResult}
+
+Perform batch ray-shape intersection test with a `SpiceAsteroid` for a matrix of rays.
+
+# Arguments
+- `rays`     : Matrix of rays at the asteroid-fixed frame
+- `asteroid` : `SpiceAsteroid` object
+
+# Returns
+- Matrix of `RayShapeIntersectionResult` objects
+"""
+function intersect_ray_shape(rays::AbstractMatrix{AsteroidShapeModels.Ray}, asteroid::SpiceAsteroid)
+    return AsteroidShapeModels.intersect_ray_shape(rays, asteroid.static.shape)
+end

--- a/src/image_generation.jl
+++ b/src/image_generation.jl
@@ -140,7 +140,7 @@ function generate_intersection_map(cam::SpiceCamera, asteroid::SpiceAsteroid)
     
     # Perform batch intersection test for all rays at once
     # This leverages the optimized batch processing in AsteroidShapeModels.jl v0.4.0
-    intersection_map = intersect_ray_shape(rays, asteroid.static.shape)
+    intersection_map = intersect_ray_shape(rays, asteroid)
     
     return intersection_map
 end


### PR DESCRIPTION
## Summary
- Update `generate_intersection_map` to use `intersect_ray_shape(rays, asteroid)` instead of direct shape access
- Add `intersect_ray_shape` methods for `AbstractVector{Ray}` and `AbstractMatrix{Ray}` in `SpiceAsteroid.jl`
- Enable support for single ray, vector of rays, and matrix of rays intersection tests

## Motivation
After updating to `AsteroidShapeModels.jl` v0.4.0 in PR #6, the batch ray processing functionality was incomplete. The `generate_intersection_map` function was calling `intersect_ray_shape` with a matrix of rays, but `FOVSimulator.jl` only had a method defined for single rays. This caused a `MethodError` when trying to use the batch processing feature.

## Changes
1. Modified `src/image_generation.jl`:
   - Changed line 143 from `intersect_ray_shape(rays, asteroid.static.shape)` to `intersect_ray_shape(rays, asteroid)`
   
2. Added to `src/SpiceAsteroid.jl`:
   - `intersect_ray_shape(rays::AbstractVector{Ray}, asteroid::SpiceAsteroid)` method
   - `intersect_ray_shape(rays::AbstractMatrix{Ray}, asteroid::SpiceAsteroid)` method

These methods properly delegate to `AsteroidShapeModels.jl`'s batch processing functions, ensuring full compatibility with v0.4.0's optimized batch ray intersection API.

🤖 Generated with [Claude Code](https://claude.ai/code)